### PR TITLE
Windows で動かすために elm コマンドのバージョンを変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -244,6 +244,15 @@
         "unzip-stream": "^0.3.0"
       }
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -2460,10 +2469,39 @@
       "dev": true
     },
     "elm": {
-      "version": "0.19.0-no-deps",
-      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.0-no-deps.tgz",
-      "integrity": "sha512-tOlSeo5Bt0Rkrt/aBjL+/a+TmAFdfeqjrOlThrhgKOoGeHt1hU7/hJ+HFMlHiODf09AQh7Anl64o7V6thzmRHw==",
-      "dev": true
+      "version": "0.19.0-bugfix6",
+      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.0-bugfix6.tgz",
+      "integrity": "sha512-nD/oK/nG26ULh94GREsILA9aQa3Gon+KKBmS0Z0MstywLWwrhuWKba8gfiIWLdnpQWHFIf+UsThk6Z71UWi6TQ==",
+      "dev": true,
+      "requires": {
+        "binwrap": "0.2.0"
+      },
+      "dependencies": {
+        "binwrap": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.2.0.tgz",
+          "integrity": "sha512-HUspivC8zPE37KJQ0S4zsNHUpymzQBinmpdMoa+JwmB6Mi+p30ywVZJcillYpbQmiX2wLykaaDJxXmwZkbaZGA==",
+          "dev": true,
+          "requires": {
+            "mustache": "^2.3.0",
+            "request": "^2.87.0",
+            "request-promise": "^4.2.0",
+            "tar": "^2.2.1",
+            "unzip-stream": "^0.3.0"
+          }
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
+        }
+      }
     },
     "elm-live": {
       "version": "3.4.0",
@@ -5405,6 +5443,18 @@
       "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
       "dev": true,
       "optional": true
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chokidar": "^3.0.2",
     "chokidar-cli": "^1.2.2",
     "cpx": "^1.5.0",
-    "elm": "^0.19.0-no-deps",
+    "elm": "^0.19.0-bugfix6",
     "elm-live": "3.4.0",
     "elm-test": "^0.19.0-rev6",
     "google-closure-compiler": "^20190528.0.0",


### PR DESCRIPTION
Windows だと elm コマンドのバージョン都合で elm-live が正常に動きません。
elm@0.19.0-bugfix6 であれば問題なく動作するので、そのようにバージョンを変更しました。